### PR TITLE
Update projects to .NET6 and build on windows server 2022

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  win: circleci/windows@2.2.0 
+  win: circleci/windows@5.0
 
 workflows:
   build-and-unittest:

--- a/Cfd.Tests/Cfd.Tests.csproj
+++ b/Cfd.Tests/Cfd.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Cfd/Cfd.csproj
+++ b/src/Cfd/Cfd.csproj
@@ -3,7 +3,7 @@
     <Description>A library generated from a OpenAPI doc</Description>
     <Copyright>No Copyright</Copyright>
     <Authors>OpenAPI</Authors>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <Version>1.0.0</Version>


### PR DESCRIPTION
Update projects to .net 6 and build on windows server 2022